### PR TITLE
Get rid of `Ltd` suffix in copyright header

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev. All rights reserved.
+ * Copyright 2018, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev Ltd. All rights reserved.
+ * Copyright 2017, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev. All rights reserved.
+ * Copyright 2018, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev Ltd. All rights reserved.
+ * Copyright 2017, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/client/src/main/java/io/spine/quickstart/client/ClientApp.java
+++ b/client/src/main/java/io/spine/quickstart/client/ClientApp.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2016, TeamDev. All rights reserved.
+ * Copyright 2018, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/client/src/main/java/io/spine/quickstart/client/ClientApp.java
+++ b/client/src/main/java/io/spine/quickstart/client/ClientApp.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2016, TeamDev Ltd. All rights reserved.
+ * Copyright 2016, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/client/src/main/java/io/spine/quickstart/client/package-info.java
+++ b/client/src/main/java/io/spine/quickstart/client/package-info.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2016, TeamDev. All rights reserved.
+ * Copyright 2018, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/client/src/main/java/io/spine/quickstart/client/package-info.java
+++ b/client/src/main/java/io/spine/quickstart/client/package-info.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2016, TeamDev Ltd. All rights reserved.
+ * Copyright 2016, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/ext.gradle
+++ b/ext.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev. All rights reserved.
+ * Copyright 2018, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/ext.gradle
+++ b/ext.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev Ltd. All rights reserved.
+ * Copyright 2017, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/model/build.gradle
+++ b/model/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev. All rights reserved.
+ * Copyright 2018, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/model/build.gradle
+++ b/model/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev Ltd. All rights reserved.
+ * Copyright 2017, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/model/src/main/java/io/spine/quickstart/task/TaskAggregate.java
+++ b/model/src/main/java/io/spine/quickstart/task/TaskAggregate.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2016, TeamDev. All rights reserved.
+ * Copyright 2018, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/model/src/main/java/io/spine/quickstart/task/TaskAggregate.java
+++ b/model/src/main/java/io/spine/quickstart/task/TaskAggregate.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2016, TeamDev Ltd. All rights reserved.
+ * Copyright 2016, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/model/src/main/java/io/spine/quickstart/task/TaskRepository.java
+++ b/model/src/main/java/io/spine/quickstart/task/TaskRepository.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2016, TeamDev. All rights reserved.
+ * Copyright 2018, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/model/src/main/java/io/spine/quickstart/task/TaskRepository.java
+++ b/model/src/main/java/io/spine/quickstart/task/TaskRepository.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2016, TeamDev Ltd. All rights reserved.
+ * Copyright 2016, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/model/src/main/java/io/spine/quickstart/task/package-info.java
+++ b/model/src/main/java/io/spine/quickstart/task/package-info.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2016, TeamDev. All rights reserved.
+ * Copyright 2018, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/model/src/main/java/io/spine/quickstart/task/package-info.java
+++ b/model/src/main/java/io/spine/quickstart/task/package-info.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2016, TeamDev Ltd. All rights reserved.
+ * Copyright 2016, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/model/src/main/proto/spine/quickstart/c/commands.proto
+++ b/model/src/main/proto/spine/quickstart/c/commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev. All rights reserved.
+ * Copyright 2018, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/model/src/main/proto/spine/quickstart/c/commands.proto
+++ b/model/src/main/proto/spine/quickstart/c/commands.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev Ltd. All rights reserved.
+ * Copyright 2017, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/model/src/main/proto/spine/quickstart/c/events.proto
+++ b/model/src/main/proto/spine/quickstart/c/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev. All rights reserved.
+ * Copyright 2018, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/model/src/main/proto/spine/quickstart/c/events.proto
+++ b/model/src/main/proto/spine/quickstart/c/events.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev Ltd. All rights reserved.
+ * Copyright 2017, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/model/src/main/proto/spine/quickstart/identifiers.proto
+++ b/model/src/main/proto/spine/quickstart/identifiers.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev. All rights reserved.
+ * Copyright 2018, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/model/src/main/proto/spine/quickstart/identifiers.proto
+++ b/model/src/main/proto/spine/quickstart/identifiers.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev Ltd. All rights reserved.
+ * Copyright 2017, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/model/src/main/proto/spine/quickstart/task.proto
+++ b/model/src/main/proto/spine/quickstart/task.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev. All rights reserved.
+ * Copyright 2018, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/model/src/main/proto/spine/quickstart/task.proto
+++ b/model/src/main/proto/spine/quickstart/task.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev Ltd. All rights reserved.
+ * Copyright 2017, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/scripts/generate-descriptor-set.gradle
+++ b/scripts/generate-descriptor-set.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev. All rights reserved.
+ * Copyright 2018, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/scripts/generate-descriptor-set.gradle
+++ b/scripts/generate-descriptor-set.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev Ltd. All rights reserved.
+ * Copyright 2017, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev. All rights reserved.
+ * Copyright 2018, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, TeamDev Ltd. All rights reserved.
+ * Copyright 2017, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/server/src/main/java/io/spine/quickstart/server/ServerApp.java
+++ b/server/src/main/java/io/spine/quickstart/server/ServerApp.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2016, TeamDev. All rights reserved.
+ * Copyright 2018, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/server/src/main/java/io/spine/quickstart/server/ServerApp.java
+++ b/server/src/main/java/io/spine/quickstart/server/ServerApp.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2016, TeamDev Ltd. All rights reserved.
+ * Copyright 2016, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/server/src/main/java/io/spine/quickstart/server/package-info.java
+++ b/server/src/main/java/io/spine/quickstart/server/package-info.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2016, TeamDev. All rights reserved.
+ * Copyright 2018, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following

--- a/server/src/main/java/io/spine/quickstart/server/package-info.java
+++ b/server/src/main/java/io/spine/quickstart/server/package-info.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2016, TeamDev Ltd. All rights reserved.
+ * Copyright 2016, TeamDev. All rights reserved.
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following


### PR DESCRIPTION
This PR fixes issue https://github.com/SpineEventEngine/core-java/issues/699 for `server-quickstart` repository.

All files having header format 

```
Copyright *year*, TeamDev Ltd. All rights reserved.
```

now have
```
Copyright 2018, TeamDev. All rights reserved.
```