### PR TITLE
App local run fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,13 @@ build/
 out/
 
 # Spine temporary artifact storage
-*/.spine/
+**/.spine/*
 model/*/.spine/
+
+# Web-specific files
+web/client/node_modules
+web/client/bundle.js
+web/client/package-lock.json
 
 # Login details to Maven repository.
 # Each workstation should have developer's login defined in this file.

--- a/web/README.md
+++ b/web/README.md
@@ -31,8 +31,8 @@ the details.
 
 In order to contemplate the web modules in action, follow these steps:
  1. In the `web/client`:
-    - assemble the JavaScript via `npm install`;
-    - build a single JavaScript artifact via `webpack`.
+    - install the module dependencies via `npm install`;
+    - assemble a single JavaScript artifact via `npm run webpack`.
  2. In the root directory, launch the server with `./gradlew :web:runServer`.
  3. Open the [main page](./client/app/index.html) in the browser.
  

--- a/web/README.md
+++ b/web/README.md
@@ -32,7 +32,7 @@ the details.
 In order to contemplate the web modules in action, follow these steps:
  1. In the `web/client`:
     - install the module dependencies via `npm install`;
-    - assemble a single JavaScript artifact via `npm run webpack`.
+    - assemble a single JavaScript artifact via `npm run build`.
  2. In the root directory, launch the server with `./gradlew :web:runServer`.
  3. Open the [main page](./client/app/index.html) in the browser.
  

--- a/web/build.gradle
+++ b/web/build.gradle
@@ -26,8 +26,12 @@ task runEmulator(type: com.github.psxpaul.task.ExecFork) {
     
     final def clientDir = project(':web:client').projectDir
     workingDir = "$clientDir/node_modules/.bin"
-    executable = './firebase-server'
-    
+
+    final def runsOnWindows = org.gradle.internal.os.OperatingSystem.current().isWindows()
+    final def extension = runsOnWindows ? '.cmd' : ''
+
+    executable = "$workingDir/firebase-server$extension"
+
     final def rulesFile = "$projectDir/firebase-rules.json" as File
     args = ['-e', '-r', rulesFile.getPath()]
 

--- a/web/client/package.json
+++ b/web/client/package.json
@@ -8,7 +8,7 @@
   },
   "license": "Apache-2.0",
   "scripts": {
-    "webpack": "webpack"
+    "build": "webpack"
   },
   "dependencies": {
     "firebase": "^5.11.1",

--- a/web/client/package.json
+++ b/web/client/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/spine-examples/server-quickstart"
   },
   "license": "Apache-2.0",
+  "scripts": {
+    "webpack": "webpack"
+  },
   "dependencies": {
     "firebase": "^5.11.1",
     "rxjs": "^6.5.0",
@@ -15,6 +18,7 @@
   },
   "devDependencies": {
     "firebase-server": "^1.0.1",
+    "webpack": "^4.32.2",
     "webpack-cli": "^3.3.1"
   }
 }


### PR DESCRIPTION
This PR brings several fixes to the scenario of running the application locally:
 - the `:web:client` JS module was provided with a missing `webpack` dependency;
 - the `build` script was added to the `:web:client`'s `package.json` file to allow assembling of the JS application with `webpack` by running `npm run build`;
 - the Gradle task for running of the Firebase emulator locally was adjusted to be insensitive for operating system; 

