### PR TITLE
Update to Spine `1.2.0`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@
  */
 
 plugins {
-    id 'io.spine.tools.gradle.bootstrap' version '1.1.2' apply false
+    id 'io.spine.tools.gradle.bootstrap' version '1.2.0' apply false
     id 'net.ltgt.errorprone' version '1.1.1' apply false
 }
 

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -22,4 +22,5 @@ spine.enableJava().client()
 
 dependencies {
     implementation project(path: ':model')
+    runtimeOnly "io.grpc:grpc-netty:$deps.versions.netty"
 }

--- a/version.gradle
+++ b/version.gradle
@@ -22,7 +22,7 @@ final def versions = [
         errorProne       : "2.3.3",
         errorProneJavac  : "9+181-r4173-1", // taken from here: https://github.com/tbroyer/gradle-errorprone-plugin/blob/v0.8/build.gradle.kts
         guava            : "28.1-jre",
-        netty            : "1.24.0",
+        netty            : "1.24.1",
         checkerFramework : "2.9.0",
         flogger          : "0.4",
         pmd              : "6.16.0",

--- a/web/client/app/index.html
+++ b/web/client/app/index.html
@@ -30,7 +30,7 @@
     <link rel="icon"
           type="image/png"
           href="https://spine.io/favicons/favicon.ico">
-    <script type="text/javascript" src="./bundle.js"></script>
+    <script type="text/javascript" src="./bundle.js" charset="utf-8"></script>
 </head>
 
 <body onload="subscribeToUpdates(document)">

--- a/web/client/package.json
+++ b/web/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quick-client",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Web client of the Quickstart project",
   "repository": {
     "type": "git",
@@ -13,12 +13,12 @@
   "dependencies": {
     "firebase": "^6.2.0",
     "rxjs": "~6.5.1",
-    "spine-web": "^1.1.2",
+    "spine-web": "^1.2.0",
     "uuid": "latest"
   },
   "devDependencies": {
     "firebase-server": "^1.0.2",
-    "webpack": "^4.32.2",
+    "webpack": "^4.41.2",
     "webpack-cli": "^3.3.1"
   }
 }


### PR DESCRIPTION
This PR updates the example to Spine of version `1.2.0`.

It also bumps some of the dependencies to match what's used in Spine `1.2.0`.